### PR TITLE
Partial Implementation of Mutation Observers

### DIFF
--- a/src/dom4/MutationRecord.hx
+++ b/src/dom4/MutationRecord.hx
@@ -37,11 +37,55 @@
 
 package dom4;
 
-/*
- * STUB
- */
+typedef MutationRecord = {
 
-class MutationRecord {
-  
-  public function new() {}
-}
+	/**
+	 * https://dom.spec.whatwg.org/#mutation-observers
+	 */
+	
+	/**
+	 * Returns attributes if the mutation was an attribute mutation, characterData if it was a mutation to a CharacterData node, and childList if it was a mutation to the tree of nodes.
+	 */
+	type:DOMString,
+	
+	/**
+	 * Returns the node the mutation affected, depending on the type. For attributes, it is the element whose attribute changed. For characterData, it is the CharacterData node. For childList, it is the node whose children changed.
+	 */
+	target:Node,
+	
+	/**
+	 * Return the nodes added. Will be an empty NodeList if no nodes were added.
+	 */
+	addedNodes:Array<Node>,
+	
+	/**
+	 * Return the nodes removed. Will be an empty NodeList if no nodes were removed.
+	 */
+	removedNodes:Array<Node>,
+	
+	/**
+	 * Return the previous sibling of the added or removed nodes, or null.
+	 */
+	previousSibling:Node,
+	
+	/**
+	 * Return the next sibling of the added or removed nodes, or null.
+	 */
+	nextSibling:Node,
+	
+	/**
+	 * Returns the local name of the changed attribute, or null.
+	 */
+	attributeName:DOMString,
+	
+	/**
+	 * Returns the namespace of the changed attribute, or null.
+	 */
+	attributeNamespace:DOMString,
+	
+	/**
+	 * The return value depends on the type. For attributes, it is the value of the changed attribute before the change. For characterData, it is the data of the changed node before the change. For childList, it is null.
+	 */
+	oldValue:DOMString
+	
+};

--- a/src/dom4/Node.hx
+++ b/src/dom4/Node.hx
@@ -75,6 +75,9 @@ class Node implements EventTarget {
   private var NOT_WHITESPACE_ONLY_EREG = new EReg("[^ \t\r\n]", "g");
 
   private var eventListeners: Array<NodeEventListener>;
+  @:allow(dom4.MutationObserver) @:allow(dom4.utils.MutationUtils)
+	private var mutationObservers: Array<{ observer:MutationObserver, options:dom4.MutationObserver.MutationObserverInit }>;
+
   /*
    * https://dom.spec.whatwg.org/#dom-node-nodetype
    */
@@ -1064,5 +1067,6 @@ class Node implements EventTarget {
 
   public function new() {
     this.eventListeners = [];
+	this.mutationObservers = [];
   }
 }

--- a/src/dom4/utils/MutationUtils.hx
+++ b/src/dom4/utils/MutationUtils.hx
@@ -52,6 +52,9 @@ class MutationUtils {
                                             addedNodes: Array<Node>, removedNodes: Array<Node>,
                                             previousSibling: Node, nextSibling: Node) : Void
   {
+	if (addedNodes == null) addedNodes = [];
+	if (removedNodes == null) removedNodes = [];
+	
 	/**
 	 * https://dom.spec.whatwg.org/#mutation-observers
 	 * 

--- a/src/dom4/utils/MutationUtils.hx
+++ b/src/dom4/utils/MutationUtils.hx
@@ -52,6 +52,61 @@ class MutationUtils {
                                             addedNodes: Array<Node>, removedNodes: Array<Node>,
                                             previousSibling: Node, nextSibling: Node) : Void
   {
-   // TBD
+	/**
+	 * https://dom.spec.whatwg.org/#mutation-observers
+	 * 
+	 * 4.3.2
+	 */
+	var interestedObservers = new Array<{observer:MutationObserver, ?oldValue:DOMString}>();
+	var node = target;
+	while (node != null) {
+		for (i in node.mutationObservers) {
+			//3.1
+			if (node != target && !i.options.subtree)
+				continue;
+			
+			//3.2
+			if (type == "attributes" && !i.options.attributes)
+				continue;
+			
+			//3.3
+			if (type == "attributes" && (namespace != null || !Lambda.has(i.options.attributeFilter, name)))
+				continue;
+			
+			//3.4
+			if (type == "characterData" && !i.options.characterData)
+				continue;
+			
+			//3.5
+			if (type == "childList" && !i.options.childList)
+				continue;
+			
+			//3.6/3.7
+			var inclOldValue =
+				(type == "attributes" && i.options.attributeOldValue) ||
+				(type == "characterData" && i.options.characterDataOldValue);
+			if (!Lambda.exists(interestedObservers, function (e) { return e.observer == i.observer; } ))
+				interestedObservers.push({ observer:i.observer, oldValue:inclOldValue ? oldValue : null });
+		}
+		
+		node = node.parentNode;
+	}
+	
+	for (i in interestedObservers) {
+		//Create MutationRecord
+		var record:dom4.MutationRecord = {
+			type: type,
+			target: target,
+			addedNodes: addedNodes,
+			removedNodes: removedNodes,
+			previousSibling: previousSibling,
+			nextSibling: nextSibling,
+			attributeName: name,
+			attributeNamespace: namespace,
+			oldValue: i.oldValue
+		};
+		
+		i.observer.enqueueRecord(record);
+	}
   }
 }

--- a/test/Test.hx
+++ b/test/Test.hx
@@ -38,6 +38,10 @@
 
 import dom4.Document;
 import dom4.DOMParser;
+import dom4.Element;
+import dom4.MutationObserver;
+import dom4.MutationRecord;
+import dom4.Node;
 import dom4.utils.BasicContentSink;
 import dom4.utils.Serializer;
 
@@ -78,6 +82,26 @@ class Test {
   </html:p>
   <myelem label="fo&quot;o" />
 </foobar>', s.serializeToString(document));
+  }
+  
+  public function testMutationObserver() {
+	var c = [];
+    new MutationObserver(function (changes:Array<MutationRecord>, obs:MutationObserver):Void {
+		for (i in changes) c.push(i);
+	}).observe(document.documentElement, {
+		childList: true,
+		subtree: true
+	});
+	var div = document.createElement('DIV');
+	var span = document.createElement('SPAN');
+	document.documentElement.removeChild(document.documentElement.children[0]);
+	document.documentElement.appendChild(div);
+	div.appendChild(span);
+	
+	Assert.equals(1, c[0].removedNodes.length);
+	Assert.equals(1, c[1].addedNodes.length);
+	Assert.equals('DIV', cast(c[1].addedNodes[0], Element).tagName);
+	Assert.equals('SPAN', cast(c[2].addedNodes[0], Element).tagName);
   }
 
   static function main() : Void {


### PR DESCRIPTION
This should include everything except "transient registered observers" for when DOM nodes are detached from parent target nodes.
